### PR TITLE
Add r and cs109a apps

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -9,11 +9,33 @@
                 "value": 2
             },
             "title": "Jupyter Notebook - General"
+        },
+        {
+            "app_name": "fas-jupyter-r",
+            "title": "Jupyter Notebook - R Kernel",
+            "docker_image": "jupyter/r-notebook",
+            "cpu": {
+                "value": 1
+            },
+            "memory": {
+                "value": 2
+            }
+        },
+        {
+            "app_name": "fas-jupyter-cs109a",
+            "title": "Jupyter Notebook - CS109a",
+            "docker_image": "harvardat/jupyter-cs109a-medium:8e619987",
+            "cpu": {
+                "value": 8
+            },
+            "memory": {
+                "value": 16
+            }
         }
     ],
     "base": {
         "app_type": "jupyter",
-        "docker_image": "harvardat/jupyter-general-small:440d315a",
+        "docker_image": "harvardat/jupyter-general-small:6f4208e2",
         "git_branch": "master",
         "git_dir": "fas-ondemand-jupyter-app",
         "git_url": "https://github.com/fasrc/fas-ondemand-jupyter-app.git"

--- a/apps/fas-jupyter-cs109a/form.yml
+++ b/apps/fas-jupyter-cs109a/form.yml
@@ -1,0 +1,39 @@
+---
+name: Jupyter Notebook - CS109a
+cluster: "academic"
+attributes:
+  modules: null
+  extra_jupyter_args: ""
+  custom_time:
+    label: "Allocated Time (expressed in MM , or HH:MM:SS , or DD-HH:MM)."
+    value: "04:00:00"
+    widget: text_field
+  bc_queue: "academic"
+  custom_email_address:
+    label: email address for status notification
+    widget: text_field
+  
+  custom_memory_per_node: 16
+  
+  
+  custom_num_cores: 8
+  
+  custom_num_gpus: 0 
+  jupyter_version: harvardat_jupyter-cs109a-medium_8e619987.sif
+  custom_reservation: null
+  envscript: null
+  bc_account:
+    label: "Slurm Account"
+    help: "If you are not in multiple labs please leave this blank."
+
+form:
+  - modules
+  - extra_jupyter_args
+  - bc_queue
+  - custom_memory_per_node
+  - custom_num_cores
+  - custom_num_gpus
+  - custom_time
+  - jupyter_version
+  - envscript
+  - custom_reservation

--- a/apps/fas-jupyter-cs109a/manifest.yml
+++ b/apps/fas-jupyter-cs109a/manifest.yml
@@ -1,0 +1,9 @@
+---
+name: Jupyter Notebook - CS109a
+category: Interactive Apps
+subcategory: Servers
+role: batch_connect
+description: |
+  This app will launch [Jupyter Notebook] on a compute node on the  FAS-RC Academic cluster:
+
+  [Jupyter Notebook]:  http://jupyter.org

--- a/apps/fas-jupyter-cs109a/submit.yml.erb
+++ b/apps/fas-jupyter-cs109a/submit.yml.erb
@@ -1,0 +1,12 @@
+---
+batch_connect:
+  template: "basic"
+script:
+  reservation_id: <%= custom_reservation %>
+  native:
+    - "--mem=<%= custom_memory_per_node.blank? ? 2 : custom_memory_per_node.to_s %>G"
+    - "--time=<%= custom_time.blank? ? "04:00:00" : custom_time.to_s %>"
+    - "--cpus-per-task=<%= custom_num_cores.blank? ? 1 : custom_num_cores.to_i %>"
+   <%- if !custom_num_gpus.to_i.zero? -%>
+    - "--gres=gpu:<%= custom_num_gpus.to_i %>"
+   <%- end -%>

--- a/apps/fas-jupyter-cs109a/template/after.sh
+++ b/apps/fas-jupyter-cs109a/template/after.sh
@@ -1,0 +1,13 @@
+# Wait for the Jupyter Notebook server to start
+echo "Waiting for Jupyter Notebook server to open port ${port}..."
+echo "TIMING - Starting wait at: $(date)"
+if wait_until_port_used "${host}:${port}" 180; then
+  echo "Discovered Jupyter Notebook server listening on port ${port}!"
+  echo "TIMING - Wait ended at: $(date)"
+else
+  echo "Timed out waiting for Jupyter Notebook server to open port ${port}!"
+  echo "TIMING - Wait ended at: $(date)"
+  pkill -P ${SCRIPT_PID}
+  clean_up 1
+fi
+sleep 2

--- a/apps/fas-jupyter-cs109a/template/before.sh.erb
+++ b/apps/fas-jupyter-cs109a/template/before.sh.erb
@@ -1,0 +1,68 @@
+# This script (`before.sh.erb`) is sourced directly into the main Bash script
+# that is run when the batch job starts up. It is called before the `script.sh`
+# is forked off into a separate process.
+#
+# There are some helpful Bash functions that are made available to this script
+# that encapsulate commonly used routines when initializing a web server:
+#
+#   - find_port
+#       Find available port in range [$1..$2]
+#       Default: 2000 65535
+#
+#   - create_passwd
+#       Generate random alphanumeric password with $1 characters
+#       Default: 32
+#
+# We **MUST** supply the following environment variables in this
+# `before.sh.erb` script so that a user can connect back to the web server when
+# it is running (case-sensitive variable names):
+#
+#   - $host (already defined earlier, so no need to define again)
+#       The host that the web server is listening on
+#
+#   - $port
+#       The port that the web server is listening on
+#
+#   - $password
+#       The plain text password used to authenticate to the web server with
+
+# Export the module function if it exists
+[[ $(type -t module) == "function" ]] && export -f module
+
+# Find available port to run server on
+port=$(find_port localhost 7000 11000 )
+
+# Generate SHA1 encrypted password (requires OpenSSL installed)
+SALT="$(create_passwd 16)"
+password="$(create_passwd 16)"
+PASSWORD_SHA1="$(echo -n "${password}${SALT}" | openssl dgst -sha1 | awk '{print $NF}')"
+
+# The `$CONFIG_FILE` environment variable is exported as it is used in the main
+# `script.sh.erb` file when launching the Jupyter Notebook server.
+export CONFIG_FILE="${PWD}/config.py"
+
+# Generate Jupyter configuration file with secure file permissions
+(
+umask 077
+cat > "${CONFIG_FILE}" << EOL
+c.NotebookApp.ip = '0.0.0.0'
+c.NotebookApp.port = ${port}
+c.NotebookApp.port_retries = 0
+c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'
+c.NotebookApp.base_url = '/node/${host}/${port}/'
+c.NotebookApp.open_browser = False
+c.NotebookApp.allow_origin = '*'
+c.NotebookApp.notebook_dir = '${HOME}'
+c.NotebookApp.disable_check_xsrf = True
+EOL
+)
+
+## For some reason with the current version of jupyter, if we use the config.py file to configure the notebook, the package nb_conda_kernels does not seem to work correctly.
+#  We will temporarily pass those attributes as command line arguments 
+export MY_JUP_PORT=${port}
+export MY_JUP_PASSWD=sha1:${SALT}:${PASSWORD_SHA1}
+export MY_JUP_BASEURL=/node/${host}/${port}/
+export JOBROOT=$PWD
+
+export CONTAINER_REPO=/n/helmod/apps/centos7/Singularity/OOD_Apps_academic_cluster/Fall_2020
+export COURSE=atg_general

--- a/apps/fas-jupyter-cs109a/template/script.sh.erb
+++ b/apps/fas-jupyter-cs109a/template/script.sh.erb
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# Benchmark info
+echo "TIMING - Starting main script at: $(date)"
+
+# Set working directory to home directory
+cd "${HOME}"
+
+#
+# Start Jupyter Notebook Server
+#
+
+<%- unless context.modules.blank? -%>
+# Purge the module environment to avoid conflicts
+module purge
+
+# Load the require modules
+module load <%= context.modules %>
+
+# List loaded modules
+module list
+<%- end -%>
+
+# Benchmark info
+echo "TIMING - Starting jupyter at: $(date)"
+export container_folder=${CONTAINER_REPO}/${COURSE}
+## when you test new installs you probaby want to drop the images locally in your home folder
+#export container_folder=$HOME/Programs/containers
+export container_image=$container_folder/<%= context.jupyter_version %>
+
+# Launch the Jupyter Notebook Server
+
+JUPYTER_TMPDIR=${TMPDIR:-/tmp}/$(id -un)-jupyter/
+## for conda
+export SINGULARITYENV_CONDA_PKGS_DIRS=${HOME}/.conda/pkgs
+## for pip
+export SINGULARITYENV_XDG_CACHE_HOME=${JUPYTER_TMPDIR}/xdg_cache_home
+## job specific tmp in case there are conflicts with different users running on the same node
+WORKDIR=/scratch/${USER}/${SLURM_JOB_ID}
+mkdir -m 700 -p ${WORKDIR}/tmp
+
+## for specific package mne
+export SINGULARITYENV_NUMBA_CACHE_DIR=$HOME/.cache
+
+# enable this only if needed for debug purpose. note that the password will appear in the output 
+# set -x
+
+export SING_GPU=""
+
+<%- if !context.custom_num_gpus.to_i.zero? -%>
+export SING_GPU="--nv"
+<%- end -%>
+
+## bind some extra stuff to be able to talk to slurm from within the container
+export SING_BINDS=" -B /etc/nsswitch.conf -B /etc/sssd/ -B /var/lib/sss -B /etc/slurm -B /slurm -B /var/run/munge  -B `which sbatch ` -B `which srun ` -B `which sacct ` -B `which scontrol ` -B `which salloc `  -B /usr/lib64/slurm/ "
+## job specific tmp dir
+export SING_BINDS=" $SING_BINDS -B ${WORKDIR}/tmp:/tmp " 
+
+cat > $JOBROOT/jupyter.script.sh <<EOF1
+#!/bin/bash
+EOF1
+
+chmod +x $JOBROOT/jupyter.script.sh
+
+<%- unless context.envscript.blank? -%>
+
+cat >> $JOBROOT/jupyter.script.sh <<EOF2
+
+[ -f <%= context.envscript.to_s %> ] && source <%= context.envscript.to_s %>
+
+EOF2
+
+<%- end -%>
+
+
+cat >> $JOBROOT/jupyter.script.sh <<EOF3
+jupyter notebook \
+           --ip='0.0.0.0' \
+           --port=${MY_JUP_PORT} \
+           --port-retries=0 \
+           --NotebookApp.password="${MY_JUP_PASSWD}" \
+           --NotebookApp.base_url="${MY_JUP_BASEURL}" \
+           --no-browser \
+           --NotebookApp.allow_origin='*' \
+           --NotebookApp.disable_check_xsrf=True
+
+EOF3
+
+singularity exec $SING_GPU $SING_BINDS $container_image $JOBROOT/jupyter.script.sh

--- a/apps/fas-jupyter-cs109a/view.html.erb
+++ b/apps/fas-jupyter-cs109a/view.html.erb
@@ -1,0 +1,6 @@
+<form action="/node/<%= host %>/<%= port %>/login" method="post" target="_blank">
+  <input type="hidden" name="password" value="<%= password %>">
+  <button class="btn btn-primary" type="submit">
+    <i class="fa fa-eye"></i> Connect to Jupyter
+  </button>
+</form>

--- a/apps/fas-jupyter-r/form.yml
+++ b/apps/fas-jupyter-r/form.yml
@@ -1,0 +1,39 @@
+---
+name: Jupyter Notebook - R Kernel
+cluster: "academic"
+attributes:
+  modules: null
+  extra_jupyter_args: ""
+  custom_time:
+    label: "Allocated Time (expressed in MM , or HH:MM:SS , or DD-HH:MM)."
+    value: "04:00:00"
+    widget: text_field
+  bc_queue: "academic"
+  custom_email_address:
+    label: email address for status notification
+    widget: text_field
+  
+  custom_memory_per_node: 2
+  
+  
+  custom_num_cores: 1
+  
+  custom_num_gpus: 0 
+  jupyter_version: jupyter_r-notebook.sif
+  custom_reservation: null
+  envscript: null
+  bc_account:
+    label: "Slurm Account"
+    help: "If you are not in multiple labs please leave this blank."
+
+form:
+  - modules
+  - extra_jupyter_args
+  - bc_queue
+  - custom_memory_per_node
+  - custom_num_cores
+  - custom_num_gpus
+  - custom_time
+  - jupyter_version
+  - envscript
+  - custom_reservation

--- a/apps/fas-jupyter-r/manifest.yml
+++ b/apps/fas-jupyter-r/manifest.yml
@@ -1,0 +1,9 @@
+---
+name: Jupyter Notebook - R Kernel
+category: Interactive Apps
+subcategory: Servers
+role: batch_connect
+description: |
+  This app will launch [Jupyter Notebook] on a compute node on the  FAS-RC Academic cluster:
+
+  [Jupyter Notebook]:  http://jupyter.org

--- a/apps/fas-jupyter-r/submit.yml.erb
+++ b/apps/fas-jupyter-r/submit.yml.erb
@@ -1,0 +1,12 @@
+---
+batch_connect:
+  template: "basic"
+script:
+  reservation_id: <%= custom_reservation %>
+  native:
+    - "--mem=<%= custom_memory_per_node.blank? ? 2 : custom_memory_per_node.to_s %>G"
+    - "--time=<%= custom_time.blank? ? "04:00:00" : custom_time.to_s %>"
+    - "--cpus-per-task=<%= custom_num_cores.blank? ? 1 : custom_num_cores.to_i %>"
+   <%- if !custom_num_gpus.to_i.zero? -%>
+    - "--gres=gpu:<%= custom_num_gpus.to_i %>"
+   <%- end -%>

--- a/apps/fas-jupyter-r/template/after.sh
+++ b/apps/fas-jupyter-r/template/after.sh
@@ -1,0 +1,13 @@
+# Wait for the Jupyter Notebook server to start
+echo "Waiting for Jupyter Notebook server to open port ${port}..."
+echo "TIMING - Starting wait at: $(date)"
+if wait_until_port_used "${host}:${port}" 180; then
+  echo "Discovered Jupyter Notebook server listening on port ${port}!"
+  echo "TIMING - Wait ended at: $(date)"
+else
+  echo "Timed out waiting for Jupyter Notebook server to open port ${port}!"
+  echo "TIMING - Wait ended at: $(date)"
+  pkill -P ${SCRIPT_PID}
+  clean_up 1
+fi
+sleep 2

--- a/apps/fas-jupyter-r/template/before.sh.erb
+++ b/apps/fas-jupyter-r/template/before.sh.erb
@@ -1,0 +1,68 @@
+# This script (`before.sh.erb`) is sourced directly into the main Bash script
+# that is run when the batch job starts up. It is called before the `script.sh`
+# is forked off into a separate process.
+#
+# There are some helpful Bash functions that are made available to this script
+# that encapsulate commonly used routines when initializing a web server:
+#
+#   - find_port
+#       Find available port in range [$1..$2]
+#       Default: 2000 65535
+#
+#   - create_passwd
+#       Generate random alphanumeric password with $1 characters
+#       Default: 32
+#
+# We **MUST** supply the following environment variables in this
+# `before.sh.erb` script so that a user can connect back to the web server when
+# it is running (case-sensitive variable names):
+#
+#   - $host (already defined earlier, so no need to define again)
+#       The host that the web server is listening on
+#
+#   - $port
+#       The port that the web server is listening on
+#
+#   - $password
+#       The plain text password used to authenticate to the web server with
+
+# Export the module function if it exists
+[[ $(type -t module) == "function" ]] && export -f module
+
+# Find available port to run server on
+port=$(find_port localhost 7000 11000 )
+
+# Generate SHA1 encrypted password (requires OpenSSL installed)
+SALT="$(create_passwd 16)"
+password="$(create_passwd 16)"
+PASSWORD_SHA1="$(echo -n "${password}${SALT}" | openssl dgst -sha1 | awk '{print $NF}')"
+
+# The `$CONFIG_FILE` environment variable is exported as it is used in the main
+# `script.sh.erb` file when launching the Jupyter Notebook server.
+export CONFIG_FILE="${PWD}/config.py"
+
+# Generate Jupyter configuration file with secure file permissions
+(
+umask 077
+cat > "${CONFIG_FILE}" << EOL
+c.NotebookApp.ip = '0.0.0.0'
+c.NotebookApp.port = ${port}
+c.NotebookApp.port_retries = 0
+c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'
+c.NotebookApp.base_url = '/node/${host}/${port}/'
+c.NotebookApp.open_browser = False
+c.NotebookApp.allow_origin = '*'
+c.NotebookApp.notebook_dir = '${HOME}'
+c.NotebookApp.disable_check_xsrf = True
+EOL
+)
+
+## For some reason with the current version of jupyter, if we use the config.py file to configure the notebook, the package nb_conda_kernels does not seem to work correctly.
+#  We will temporarily pass those attributes as command line arguments 
+export MY_JUP_PORT=${port}
+export MY_JUP_PASSWD=sha1:${SALT}:${PASSWORD_SHA1}
+export MY_JUP_BASEURL=/node/${host}/${port}/
+export JOBROOT=$PWD
+
+export CONTAINER_REPO=/n/helmod/apps/centos7/Singularity/OOD_Apps_academic_cluster/Fall_2020
+export COURSE=atg_general

--- a/apps/fas-jupyter-r/template/script.sh.erb
+++ b/apps/fas-jupyter-r/template/script.sh.erb
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# Benchmark info
+echo "TIMING - Starting main script at: $(date)"
+
+# Set working directory to home directory
+cd "${HOME}"
+
+#
+# Start Jupyter Notebook Server
+#
+
+<%- unless context.modules.blank? -%>
+# Purge the module environment to avoid conflicts
+module purge
+
+# Load the require modules
+module load <%= context.modules %>
+
+# List loaded modules
+module list
+<%- end -%>
+
+# Benchmark info
+echo "TIMING - Starting jupyter at: $(date)"
+export container_folder=${CONTAINER_REPO}/${COURSE}
+## when you test new installs you probaby want to drop the images locally in your home folder
+#export container_folder=$HOME/Programs/containers
+export container_image=$container_folder/<%= context.jupyter_version %>
+
+# Launch the Jupyter Notebook Server
+
+JUPYTER_TMPDIR=${TMPDIR:-/tmp}/$(id -un)-jupyter/
+## for conda
+export SINGULARITYENV_CONDA_PKGS_DIRS=${HOME}/.conda/pkgs
+## for pip
+export SINGULARITYENV_XDG_CACHE_HOME=${JUPYTER_TMPDIR}/xdg_cache_home
+## job specific tmp in case there are conflicts with different users running on the same node
+WORKDIR=/scratch/${USER}/${SLURM_JOB_ID}
+mkdir -m 700 -p ${WORKDIR}/tmp
+
+## for specific package mne
+export SINGULARITYENV_NUMBA_CACHE_DIR=$HOME/.cache
+
+# enable this only if needed for debug purpose. note that the password will appear in the output 
+# set -x
+
+export SING_GPU=""
+
+<%- if !context.custom_num_gpus.to_i.zero? -%>
+export SING_GPU="--nv"
+<%- end -%>
+
+## bind some extra stuff to be able to talk to slurm from within the container
+export SING_BINDS=" -B /etc/nsswitch.conf -B /etc/sssd/ -B /var/lib/sss -B /etc/slurm -B /slurm -B /var/run/munge  -B `which sbatch ` -B `which srun ` -B `which sacct ` -B `which scontrol ` -B `which salloc `  -B /usr/lib64/slurm/ "
+## job specific tmp dir
+export SING_BINDS=" $SING_BINDS -B ${WORKDIR}/tmp:/tmp " 
+
+cat > $JOBROOT/jupyter.script.sh <<EOF1
+#!/bin/bash
+EOF1
+
+chmod +x $JOBROOT/jupyter.script.sh
+
+<%- unless context.envscript.blank? -%>
+
+cat >> $JOBROOT/jupyter.script.sh <<EOF2
+
+[ -f <%= context.envscript.to_s %> ] && source <%= context.envscript.to_s %>
+
+EOF2
+
+<%- end -%>
+
+
+cat >> $JOBROOT/jupyter.script.sh <<EOF3
+jupyter notebook \
+           --ip='0.0.0.0' \
+           --port=${MY_JUP_PORT} \
+           --port-retries=0 \
+           --NotebookApp.password="${MY_JUP_PASSWD}" \
+           --NotebookApp.base_url="${MY_JUP_BASEURL}" \
+           --no-browser \
+           --NotebookApp.allow_origin='*' \
+           --NotebookApp.disable_check_xsrf=True
+
+EOF3
+
+singularity exec $SING_GPU $SING_BINDS $container_image $JOBROOT/jupyter.script.sh

--- a/apps/fas-jupyter-r/view.html.erb
+++ b/apps/fas-jupyter-r/view.html.erb
@@ -1,0 +1,6 @@
+<form action="/node/<%= host %>/<%= port %>/login" method="post" target="_blank">
+  <input type="hidden" name="password" value="<%= password %>">
+  <button class="btn btn-primary" type="submit">
+    <i class="fa fa-eye"></i> Connect to Jupyter
+  </button>
+</form>


### PR DESCRIPTION
This PR adds two jupyter apps for the fasrc onDemand system:

- `fas-jupyter-r` jupyter with an r kernel and tidyverse
- `fas-jupyter-cs109a` jupyter with extra compute and (so far) cs109a's environment from last year with tensorflow and keras removed