### PR TITLE
Switch general jupyter app to new image tag

### DIFF
--- a/apps/fas-jupyter-general/form.yml
+++ b/apps/fas-jupyter-general/form.yml
@@ -21,7 +21,7 @@ attributes:
   custom_num_cores: 2
   
   custom_num_gpus: 0 
-  jupyter_version: harvardat_jupyter-general-small_47a81351.sif
+  jupyter_version: harvardat_jupyter-general-small_196f61e8.sif
   custom_reservation: null
   envscript: null
   bc_account:


### PR DESCRIPTION
This PR should be merged when the newest "general" jupyter image is pulled onto the cluster. The new image contains the `cartopy` package that has been requested. 