### PR TITLE
Update apps.json to mirror updated commit hash

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -46,7 +46,7 @@
     ],
     "base": {
         "app_type": "jupyter",
-        "docker_image": "harvardat/jupyter-general-small:e1eda52d",
+        "docker_image": "harvardat/jupyter-general-small:5f9ff6c2",
         "git_branch": "master",
         "git_dir": "fas-ondemand-jupyter-app",
         "git_url": "https://github.com/fasrc/fas-ondemand-jupyter-app.git"


### PR DESCRIPTION
This is a follow-up to [PR#11](https://github.com/fasrc/fas-ondemand-jupyter-apps/pull/11) to update the the `apps.json` with the correct commit hash