### PR TITLE
Update fas-jupyter-r image

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -13,7 +13,7 @@
         {
             "app_name": "fas-jupyter-r",
             "title": "Jupyter Notebook - R Kernel",
-            "docker_image": "jupyter/r-notebook",
+            "docker_image": "harvardat/fas-jupyter-r:latest",
             "cpu": {
                 "value": 2
             },

--- a/apps/fas-jupyter-r/Dockerfile
+++ b/apps/fas-jupyter-r/Dockerfile
@@ -4,3 +4,42 @@ FROM jupyter/r-notebook
 #   https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-r-notebook
 #
 # Install additional packages here.
+
+USER root
+
+RUN apt-get -y update
+RUN apt-get -y install libnss3 gnupg
+
+#RUN curl -sSL "https://dl.google.com/linux/linux_signing_key.pub" | apt-key add -
+#RUN echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+
+#RUN apt-get -y update && apt-get -y install google-chrome-stable
+RUN apt-get -y update && apt-get -y install chromium-chromedriver
+
+# Update conda
+RUN conda update --quiet --yes conda
+
+# Add extra conda channels
+RUN conda config --append channels conda-forge \
+    --append channels anaconda-fusion \
+    --append channels jmcmurray
+
+RUN conda install --quiet --yes \
+    'mkl-service' \
+    'gensim' \
+    && \
+    conda clean --al -f -y
+
+
+
+COPY requirements.txt .
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+RUN rm requirements.txt
+
+USER $NB_UID
+
+RUN pyppeteer-install
+
+WORKDIR $HOME

--- a/apps/fas-jupyter-r/Dockerfile
+++ b/apps/fas-jupyter-r/Dockerfile
@@ -3,5 +3,4 @@ FROM jupyter/r-notebook
 # For details on the base image:
 #   https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-r-notebook
 #
-# Additional packages should be installed here.
-
+# Install additional packages here.

--- a/apps/fas-jupyter-r/Dockerfile
+++ b/apps/fas-jupyter-r/Dockerfile
@@ -1,0 +1,7 @@
+FROM jupyter/r-notebook
+
+# For details on the base image:
+#   https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-r-notebook
+#
+# Additional packages should be installed here.
+

--- a/apps/fas-jupyter-r/requirements.txt
+++ b/apps/fas-jupyter-r/requirements.txt
@@ -1,0 +1,3 @@
+nbconvert==6.5.0
+pyppeteer==1.0.2
+jupyter-client==7.3.4


### PR DESCRIPTION
This PR adds a `Dockerfile` to the `fas-jupyter-r` app so that additional packages can be installed. The docker image is pushed to github here: https://hub.docker.com/r/harvardat/fas-jupyter-r
