### PR TITLE
Update fas-jupyter-cs109a

### DIFF
--- a/apps/fas-jupyter-cs109a/Dockerfile
+++ b/apps/fas-jupyter-cs109a/Dockerfile
@@ -1,6 +1,6 @@
 FROM jupyter/scipy-notebook:notebook-6.4.12
 # reference https://github.com/jupyter/docker-stacks/blob/main/scipy-notebook/Dockerfile
-# for libraries already installed via `mamba` 
+# for libraries already installed via `mamba`
 
 USER root
 
@@ -71,6 +71,7 @@ RUN mamba install --quiet --yes \
     'pandas' \
     'papermill' \
     'pillow' \
+    'plotly' \
     'requests' \
     'retrolab' \
     'scipy' \

--- a/apps/fas-jupyter-cs109a/environment.yml
+++ b/apps/fas-jupyter-cs109a/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_kmp_llvm
   - alembic=1.8.1=pyhd8ed1ab_0
-  - alsa-lib=1.2.6.1=h7f98852_0
+  - alsa-lib=1.2.7.2=h166bdaf_0
   - altair=4.2.0=pyhd8ed1ab_1
   - ansiwrap=0.8.4=py_0
   - anyio=3.6.1=pyhd8ed1ab_1
@@ -36,48 +36,48 @@ dependencies:
   - bzip2=1.0.8=h7f98852_4
   - c-ares=1.18.1=h7f98852_0
   - c-blosc2=2.3.1=h7a311fb_0
-  - ca-certificates=2022.6.15=ha878542_0
+  - ca-certificates=2022.6.15.1=ha878542_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
-  - certifi=2022.6.15=pyhd8ed1ab_1
   - certipy=0.1.3=py_0
   - cffi=1.15.1=py310h255011f_0
   - cfitsio=4.1.0=hd9d235c_0
   - charls=2.3.4=h9c3ff4c_0
   - charset-normalizer=2.1.1=pyhd8ed1ab_0
   - click=8.1.3=py310hff52083_0
-  - cloudpickle=2.1.0=pyhd8ed1ab_0
+  - cloudpickle=2.2.0=pyhd8ed1ab_0
   - colorama=0.4.5=pyhd8ed1ab_0
   - conda=4.14.0=py310hff52083_0
   - conda-package-handling=1.8.1=py310h5764c6d_1
-  - configurable-http-proxy=4.5.1=node17_h7e777a6_1
+  - configurable-http-proxy=4.5.3=node17_h7e777a6_0
   - cryptography=37.0.4=py310h597c629_0
   - cycler=0.11.0=pyhd8ed1ab_0
   - cython=0.29.32=py310hd8f1fbe_0
   - cytoolz=0.12.0=py310h5764c6d_0
-  - dask=2022.8.1=pyhd8ed1ab_2
-  - dask-core=2022.8.1=pyhd8ed1ab_0
+  - dask=2022.9.0=pyhd8ed1ab_0
+  - dask-core=2022.9.0=pyhd8ed1ab_0
   - dav1d=1.0.0=h166bdaf_1
   - dbus=1.13.6=h5008d03_3
   - debugpy=1.6.3=py310hd8f1fbe_0
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
   - dill=0.3.5.1=pyhd8ed1ab_0
-  - distributed=2022.8.1=pyhd8ed1ab_2
+  - distributed=2022.9.0=pyhd8ed1ab_0
   - entrypoints=0.4=pyhd8ed1ab_0
+  - executing=1.0.0=pyhd8ed1ab_0
   - expat=2.4.8=h27087fc_0
-  - fftw=3.3.10=nompi_ha7695d1_103
+  - fftw=3.3.10=nompi_hf0379b8_105
   - flit-core=3.7.1=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
   - font-ttf-ubuntu=0.83=hab24e00_0
-  - fontconfig=2.14.0=h8e229c2_0
+  - fontconfig=2.14.0=hc2a2eb6_1
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
   - fonttools=4.37.1=py310h5764c6d_0
   - freetype=2.12.1=hca18f0e_0
-  - fsspec=2022.7.1=pyhd8ed1ab_0
+  - fsspec=2022.8.2=pyhd8ed1ab_0
   - gettext=0.19.8.1=h73d1719_1008
   - giflib=5.2.1=h36c2ea0_2
   - glib=2.72.1=h6239696_0
@@ -85,35 +85,32 @@ dependencies:
   - gmp=6.2.1=h58526e2_0
   - gmpy2=2.1.2=py310h92f7908_0
   - greenlet=1.1.3=py310hd8f1fbe_0
-  - gst-plugins-base=1.20.3=hf6a322e_0
-  - gstreamer=1.20.3=hd4edc92_0
+  - gst-plugins-base=1.20.3=h57caac4_1
+  - gstreamer=1.20.3=hd4edc92_1
   - h5py=3.7.0=nompi_py310h416281c_101
   - hdf5=1.12.2=nompi_h2386368_100
   - heapdict=1.0.1=py_0
   - icu=70.1=h27087fc_0
   - idna=3.3=pyhd8ed1ab_0
-  - imagecodecs=2022.8.8=py310h61cb99f_4
-  - imageio=2.21.1=pyhfa7a67d_0
+  - imagecodecs=2022.8.8=py310h112de15_5
+  - imageio=2.21.3=pyhfa7a67d_0
   - importlib_metadata=4.11.4=hd8ed1ab_0
   - importlib_resources=5.9.0=pyhd8ed1ab_0
-  - ipykernel=6.15.1=pyh210e3f2_0
   - ipympl=0.9.2=pyhd8ed1ab_0
-  - ipython=8.4.0=pyh41d4057_1
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.7.2=pyhd8ed1ab_0
-  - jack=1.9.18=h8c3723f_1002
+  - jack=1.9.18=h8c3723f_1003
   - jedi=0.18.1=pyhd8ed1ab_2
   - jinja2=3.1.2=pyhd8ed1ab_1
   - joblib=1.1.0=pyhd8ed1ab_0
   - jpeg=9e=h166bdaf_2
   - json5=0.9.5=pyh9f0ad1d_0
-  - jsonschema=4.14.0=pyhd8ed1ab_0
   - jupyter_core=4.11.1=py310hff52083_0
   - jupyter_server=1.18.1=pyhd8ed1ab_0
   - jupyter_telemetry=0.1.0=pyhd8ed1ab_1
   - jupyterhub=2.3.1=pyhd8ed1ab_0
   - jupyterhub-base=2.3.1=pyhd8ed1ab_0
-  - jupyterlab=3.4.5=pyhd8ed1ab_0
+  - jupyterlab=3.4.6=pyhd8ed1ab_0
   - jupyterlab_pygments=0.2.2=pyhd8ed1ab_0
   - jupyterlab_server=2.15.1=pyhd8ed1ab_0
   - jupyterlab_widgets=1.1.1=pyhd8ed1ab_0
@@ -131,14 +128,14 @@ dependencies:
   - libbrotlicommon=1.0.9=h166bdaf_7
   - libbrotlidec=1.0.9=h166bdaf_7
   - libbrotlienc=1.0.9=h166bdaf_7
-  - libcap=2.64=ha37c62d_0
+  - libcap=2.65=ha37c62d_0
   - libcblas=3.9.0=16_linux64_openblas
   - libclang=14.0.6=default_h2e3cab8_0
   - libclang13=14.0.6=default_h3a83d3e_0
   - libcups=2.3.3=h3e49a29_2
   - libcurl=7.83.1=h7bff187_0
   - libdb=6.2.32=h9c3ff4c_0
-  - libdeflate=1.13=h166bdaf_0
+  - libdeflate=1.14=h166bdaf_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=h516909a_1
   - libevent=2.1.10=h9b69904_4
@@ -159,18 +156,18 @@ dependencies:
   - libnghttp2=1.47.0=hdcd2b5c_1
   - libnsl=2.0.0=h7f98852_0
   - libogg=1.3.4=h7f98852_1
-  - libopenblas=0.3.21=pthreads_h78a6416_2
+  - libopenblas=0.3.21=pthreads_h78a6416_3
   - libopus=1.3.1=h7f98852_1
   - libpng=1.6.37=h753d276_4
   - libpq=14.5=hd77ab85_0
-  - libprotobuf=3.21.5=h6239696_0
+  - libprotobuf=3.21.5=h6239696_3
   - libsndfile=1.0.31=h9c3ff4c_1
   - libsodium=1.0.18=h36c2ea0_1
   - libsolv=0.7.22=h6239696_0
-  - libsqlite=3.39.2=h753d276_1
+  - libsqlite=3.39.3=h753d276_0
   - libssh2=1.10.0=haa6b8db_3
   - libstdcxx-ng=12.1.0=ha89aaad_16
-  - libtiff=4.4.0=h0e0dad5_3
+  - libtiff=4.4.0=h55922b4_4
   - libtool=2.4.6=h9c3ff4c_1008
   - libudev1=249=h166bdaf_4
   - libuuid=2.32.1=h7f98852_1000
@@ -190,7 +187,7 @@ dependencies:
   - lz4=4.0.0=py310h5d5e884_2
   - lz4-c=1.9.3=h9c3ff4c_1
   - lzo=2.10=h516909a_1000
-  - mako=1.2.1=pyhd8ed1ab_0
+  - mako=1.2.2=pyhd8ed1ab_0
   - mamba=0.25.0=py310hf87f941_2
   - markupsafe=2.1.1=py310h5764c6d_1
   - matplotlib=3.5.3=py310hff52083_2
@@ -218,19 +215,17 @@ dependencies:
   - nss=3.78=h2350873_0
   - numba=0.55.2=py310ha5257ce_0
   - numexpr=2.8.3=py310hf05e7a9_100
-  - oauthlib=3.2.0=pyhd8ed1ab_0
-  - openblas=0.3.21=pthreads_h320a7e8_2
+  - openblas=0.3.21=pthreads_h320a7e8_3
   - openjpeg=2.5.0=h7d73246_1
   - openssl=1.1.1q=h166bdaf_0
   - packaging=21.3=pyhd8ed1ab_0
   - pamela=1.0.0=py_0
-  - pandas=1.4.3=py310h769672d_0
   - pandoc=2.19.2=ha770c72_0
   - pandocfilters=1.5.0=pyhd8ed1ab_0
   - papermill=2.3.4=pyhd8ed1ab_0
   - parso=0.8.3=pyhd8ed1ab_0
   - partd=1.3.0=pyhd8ed1ab_0
-  - pathspec=0.9.0=pyhd8ed1ab_0
+  - pathspec=0.10.1=pyhd8ed1ab_0
   - patsy=0.5.2=pyhd8ed1ab_0
   - pcre=8.45=h9c3ff4c_0
   - pexpect=4.8.0=pyh9f0ad1d_2
@@ -239,15 +234,14 @@ dependencies:
   - pip=22.2.2=pyhd8ed1ab_0
   - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_0
   - platformdirs=2.5.2=pyhd8ed1ab_1
+  - plotly=5.10.0=pyhd8ed1ab_0
   - ply=3.11=py_1
-  - portaudio=19.6.0=h57a0ea0_5
+  - portaudio=19.6.0=h8e90077_6
   - prometheus_client=0.14.1=pyhd8ed1ab_0
-  - prompt-toolkit=3.0.30=pyha770c72_0
-  - protobuf=4.21.5=py310hd8f1fbe_0
-  - psutil=5.9.1=py310h5764c6d_0
+  - protobuf=4.21.5=py310hd8f1fbe_1
   - pthread-stubs=0.4=h36c2ea0_1001
   - ptyprocess=0.7.0=pyhd3deb0d_0
-  - pulseaudio=14.0=h7f54b18_8
+  - pulseaudio=14.0=h0868958_9
   - pure_eval=0.2.2=pyhd8ed1ab_0
   - pybind11-abi=4=hd8ed1ab_3
   - pycosat=0.6.3=py310h5764c6d_1010
@@ -271,30 +265,30 @@ dependencies:
   - pywavelets=1.3.0=py310hde88566_1
   - pyyaml=6.0=py310h5764c6d_4
   - pyzmq=23.2.1=py310h330234f_0
-  - qt-main=5.15.4=ha5833f6_2
+  - qt-main=5.15.6=hc525480_0
   - readline=8.1.2=h0f457ee_0
   - reproc=14.2.3=h7f98852_0
   - reproc-cpp=14.2.3=h9c3ff4c_0
-  - requests=2.28.1=pyhd8ed1ab_0
+  - requests=2.28.1=pyhd8ed1ab_1
   - retrolab=0.3.21=pyhd8ed1ab_0
   - ruamel.yaml=0.17.21=py310h5764c6d_1
   - ruamel.yaml.clib=0.2.6=py310h5764c6d_1
   - ruamel_yaml=0.15.80=py310h5764c6d_1007
   - scikit-image=0.19.3=py310h769672d_1
   - scikit-learn=1.1.2=py310h0c3af53_0
-  - scipy=1.9.0=py310hdfbd76f_0
-  - seaborn=0.11.2=hd8ed1ab_0
-  - seaborn-base=0.11.2=pyhd8ed1ab_0
+  - scipy=1.9.1=py310hdfbd76f_0
+  - seaborn=0.12.0=hd8ed1ab_0
+  - seaborn-base=0.12.0=pyhd8ed1ab_0
   - send2trash=1.8.0=pyhd8ed1ab_0
   - setuptools=65.3.0=pyhd8ed1ab_1
   - sip=6.6.2=py310hd8f1fbe_0
   - six=1.16.0=pyh6c4a22f_0
   - snappy=1.1.9=hbd366e4_1
-  - sniffio=1.2.0=py310hff52083_3
+  - sniffio=1.3.0=pyhd8ed1ab_0
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
   - soupsieve=2.3.2.post1=pyhd8ed1ab_0
-  - sqlalchemy=1.4.40=py310h5764c6d_0
-  - sqlite=3.39.2=h4ff8645_1
+  - sqlalchemy=1.4.41=py310h5764c6d_0
+  - sqlite=3.39.3=h4ff8645_0
   - stack_data=0.5.0=pyhd8ed1ab_0
   - statsmodels=0.13.2=py310hde88566_0
   - sympy=1.10.1=py310hff52083_1
@@ -309,7 +303,6 @@ dependencies:
   - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.1=pyhd8ed1ab_0
   - toolz=0.12.0=pyhd8ed1ab_0
-  - tqdm=4.64.0=pyhd8ed1ab_0
   - traitlets=5.3.0=pyhd8ed1ab_0
   - typing_extensions=4.3.0=pyha770c72_0
   - tzdata=2022c=h191b570_0
@@ -317,7 +310,7 @@ dependencies:
   - voila=0.3.6=pyhd8ed1ab_0
   - wcwidth=0.2.5=pyh9f0ad1d_2
   - webencodings=0.5.1=py_1
-  - websocket-client=1.4.0=pyhd8ed1ab_0
+  - websocket-client=1.4.1=pyhd8ed1ab_0
   - websockets=10.3=py310h5764c6d_0
   - wheel=0.37.1=pyhd8ed1ab_0
   - widgetsnbextension=3.6.1=pyha770c72_0
@@ -344,8 +337,8 @@ dependencies:
     - appdirs==1.4.4
     - appnope==0.1.3
     - cachetools==5.2.0
+    - certifi==2022.6.15
     - docutils==0.19
-    - executing==1.0.0
     - fica==0.2.0
     - google-api-core==2.8.2
     - google-api-python-client==2.58.0
@@ -357,6 +350,9 @@ dependencies:
     - httplib2==0.20.4
     - imagesize==1.4.1
     - importlib-metadata==4.12.0
+    - ipykernel==6.15.1
+    - ipython==8.4.0
+    - jsonschema==4.14.0
     - jupyter-client==7.3.5
     - jupytext==1.14.1
     - markdown-it-py==2.1.0
@@ -367,7 +363,11 @@ dependencies:
     - nbconvert==7.0.0
     - nbopen==0.6
     - numpy==1.23.2
+    - oauthlib==3.2.0
     - otter-grader==4.0.0
+    - pandas==1.4.3
+    - prompt-toolkit==3.0.30
+    - psutil==5.9.1
     - pyasn1==0.4.8
     - pyasn1-modules==0.2.8
     - pydantic==1.9.2
@@ -385,6 +385,7 @@ dependencies:
     - sphinxcontrib-qthelp==1.0.3
     - sphinxcontrib-serializinghtml==1.1.5
     - tornado==6.2
+    - tqdm==4.64.0
     - typer==0.6.1
     - uritemplate==4.1.1
     - urllib3==1.26.12

--- a/apps/fas-jupyter-cs109a/form.yml
+++ b/apps/fas-jupyter-cs109a/form.yml
@@ -13,13 +13,13 @@ attributes:
   custom_email_address:
     label: email address for status notification
     widget: text_field
-  
+
   custom_memory_per_node: 16
-  
-  
-  custom_num_cores: 8
-  
-  custom_num_gpus: 0 
+
+
+  custom_num_cores: 4
+
+  custom_num_gpus: 0
   jupyter_version: harvardat_fas-jupyter-cs109a_5f864be5.sif
   custom_reservation: null
   envscript: null

--- a/apps/fas-jupyter-cs109a/form.yml
+++ b/apps/fas-jupyter-cs109a/form.yml
@@ -20,7 +20,7 @@ attributes:
   custom_num_cores: 4
 
   custom_num_gpus: 0
-  jupyter_version: harvardat_fas-jupyter-cs109a_5f864be5.sif
+  jupyter_version: harvardat_fas-jupyter-cs109a_sha-b54bda8.sif
   custom_reservation: null
   envscript: null
   bc_account:


### PR DESCRIPTION
This PR updates the `fas-jupyter-cs109a` app.

Changes:
- Added [plotly](https://anaconda.org/conda-forge/plotly) package as requested by Chris Gumb.
- Updated `environment.yml` with the list of installed packages.
- Changed `form.yml` cpu setting from 8 cores to 4 cores so that it is aligned with the 16GB memory allocated.
- Updated `form.yml` to point to latest image `harvardat/fas-jupyter-cs109a:sha-b54bda8`

@raminderj @jaguillette 